### PR TITLE
Removed obfuscation of code in preparation for new chrome rules

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -324,15 +324,23 @@ module.exports = function (grunt) {
     //     }
     //   }
     // },
-    // uglify: {
-    //   dist: {
-    //     files: {
-    //       '<%= config.dist %>/scripts/scripts.js': [
-    //         '<%= config.dist %>/scripts/scripts.js'
-    //       ]
-    //     }
-    //   }
-    // },
+
+    uglify: {
+      options: {
+        beautify: true,
+        compress: false,
+        enclose: {},
+        mangle: false
+      },
+      dist: {
+        files: {
+          '<%= config.dist %>/scripts/scripts.js': [
+            '<%= config.dist %>/scripts/scripts.js'
+          ]
+        }
+      }
+    },
+
     // concat: {
     //   dist: {}
     // },


### PR DESCRIPTION
Google is banning obfuscation in extensions. Firefox already does this
effectively. I have nothing to hide, so I might as well just disable
it now.